### PR TITLE
EM-434 :alien: feat(Connection): adding connection status!

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -13,6 +13,7 @@ import (
 
 type Controller interface {
 	ProcessWalletCommand(command query.WalletCommanderCommand)
+	UpdateClientConnected(clientId string, conncted bool)
 }
 
 type WalletCommanderController struct {
@@ -27,6 +28,10 @@ func New(vault vault.Vault, store store.Store, client client.Client) (Controller
 		vault:  vault,
 		store:  store,
 	}, nil
+}
+
+func (w *WalletCommanderController) UpdateClientConnected(clientId string, connected bool) {
+	w.store.UpdateWalletCommanderActiveClient(clientId, connected)
 }
 
 func (w *WalletCommanderController) ProcessWalletCommand(command query.WalletCommanderCommand) {

--- a/internal/controller/dev_controller.go
+++ b/internal/controller/dev_controller.go
@@ -26,6 +26,10 @@ func NewDevController(serverEndpoint string, mode types.DevMockMode) Controller 
 	}
 }
 
+func (d *DevController) UpdateClientConnected(clientId string, connected bool) {
+	d.store.UpdateWalletCommanderActiveClient(clientId, connected)
+}
+
 func (d *DevController) ProcessWalletCommand(command query.WalletCommanderCommand) {
 	commandId := command.Id.(string)
 	log.Logger().Infof("Dev Server in mode %s is processing command %s", d.mode, commandId)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/earn-alliance/wallet-commander-cli/pkg/api"
 	"github.com/hasura/go-graphql-client"
+	"time"
 )
 
 var WallterCommanderSubscription struct {
@@ -30,6 +31,20 @@ func NewUpdateCommandResultsVars(
 		"transactionHash": graphql.String(transactionHash),
 		"status":          wallet_commander_command_statuses_enum(status),
 		"message":         graphql.String(statusMessage),
+	}
+}
+
+var UpsertWalletCommanderActiveClients struct {
+	InsertWalletCommanderActiveClients struct {
+		Client_Id string
+	} `graphql:"insert_wallet_commander_active_clients_one(object:{ client_id: $clientId, last_ping_time: $lastPingTime, last_connected_status: $connected }, on_conflict:{ constraint:wallet_commander_active_clients_pkey, update_columns:[client_id,last_ping_time,last_connected_status]})"`
+}
+
+func NewUpsertWalletCommanderActiveClientVars(clientId string, connected bool) map[string]interface{} {
+	return map[string]interface{}{
+		"clientId":     uuid(clientId),
+		"connected":    graphql.Boolean(connected),
+		"lastPingTime": timestamptz(time.Now().Format("2006-01-02 15:04:05")),
 	}
 }
 

--- a/internal/query/scalar.go
+++ b/internal/query/scalar.go
@@ -4,4 +4,5 @@ type (
 	// Hasura custom grapqhl type for query - this is all lower case on purpose
 	uuid                                   string
 	wallet_commander_command_statuses_enum string
+	timestamptz                            string
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,10 +11,17 @@ import (
 type Store interface {
 	UpdateWalletCommandTransactionSuccess(id string, transaction string)
 	UpdateWalletCommandTransactionError(id string, status api.WalletCommanderStatus, msg string)
+	UpdateWalletCommanderActiveClient(clientId string, connected bool)
 }
 
 type WalletCommanderStore struct {
 	client *graphql.Client
+}
+
+func New(graphqlServerEndpoint string) Store {
+	return &WalletCommanderStore{
+		client: graphql.NewClient(graphqlServerEndpoint, nil),
+	}
 }
 
 func (w *WalletCommanderStore) UpdateWalletCommandTransactionSuccess(id string, transaction string) {
@@ -43,8 +50,13 @@ func (w *WalletCommanderStore) UpdateWalletCommandTransactionError(id string, st
 	}
 }
 
-func New(graphqlServerEndpoint string) Store {
-	return &WalletCommanderStore{
-		client: graphql.NewClient(graphqlServerEndpoint, nil),
+func (w *WalletCommanderStore) UpdateWalletCommanderActiveClient(clientId string, connected bool) {
+	err := w.client.Mutate(context.Background(), &query.UpsertWalletCommanderActiveClients, query.NewUpsertWalletCommanderActiveClientVars(
+		clientId,
+		connected,
+	))
+
+	if err != nil {
+		log.Logger().Errorf("could not update wallet command active clients to a errored state with err: %v", err)
 	}
 }


### PR DESCRIPTION
This is in regards to EM-434 - updating wallet command to have active status on the backend.

When starting up the client, it will set the timestamp + active to true.
When shutting down the client, it will set the timestamp and active to false.