### PR TITLE
fixed axie account login flow, changed random gas limit to 1e7

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,6 +33,7 @@ const (
 	HOUR_PER_DAY                  = 24
 	DAYS_BETWEEN_CLAIM            = 14
 	DURATION_BETWEEN_CLAIMS       = time.Hour * HOUR_PER_DAY * DAYS_BETWEEN_CLAIM
+	GAS_LIMIT                     = 1000000
 )
 
 var (
@@ -185,10 +186,6 @@ func New() (Client, error) {
 }
 
 func (c *AxieClient) createTransactOps(ctx context.Context, privateKeyStr string) (*bind.TransactOpts, error) {
-	return c.createTransactOpsWithGasLimitRange(ctx, privateKeyStr, 1000000)
-}
-
-func (c *AxieClient) createTransactOpsWithGasLimitRange(ctx context.Context, privateKeyStr string, gasLimit uint64) (*bind.TransactOpts, error) {
 	privateKey, err := crypto.ToECDSA(common.FromHex(privateKeyStr))
 
 	if err != nil {
@@ -217,7 +214,7 @@ func (c *AxieClient) createTransactOpsWithGasLimitRange(ctx context.Context, pri
 	// gasLimit := uint64(rand.Int63n(upperGasLimit-lowerGasLimit+1) + lowerGasLimit)
 	ops.Nonce = big.NewInt(int64(nonce))
 	ops.GasPrice = defaultGasPriceWei
-	ops.GasLimit = gasLimit
+	ops.GasLimit = GAS_LIMIT
 	ops.Context = ctx
 
 	ops.Signer = func(address common.Address, transaction *types.Transaction) (*types.Transaction, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -541,7 +541,7 @@ func (c *AxieClient) ClaimOriginSlp(
 	}
 
 	claimableResponse, err := c.getClaimableSlpPayload(token)
-	log.Printf("claimable resp %v", claimableResponse)
+	// log.Printf("claimable resp %v", claimableResponse)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -555,7 +555,7 @@ func (c *AxieClient) ClaimOriginSlp(
 		))
 	}
 
-	withdrawSlpResponse, err := c.getWithdrawSlpPayload(token, 1)
+	withdrawSlpResponse, err := c.getWithdrawSlpPayload(token, claimableResponse.GetClaimableAmount())
 
 	//log.Printf("withdraw slp resp %v", withdrawSlpResponse)
 


### PR DESCRIPTION
- the original random gas limit behavior fails when user claim origin slp, this is changed to a relatively large static number to avoid random fails
- updated axie's login flow for checking claimable amount